### PR TITLE
Update plugin to note that this isn't needed in 0.4.x

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[*.mk]
+insert_final_newline = true
+indent_style = tab
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: required
+language: bash
+env:
+  - DOKKU_VERSION=master
+before_install: make setup
+script: make test

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Paul d'Hubert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+shellcheck:
+ifeq ($(shell shellcheck > /dev/null 2>&1 ; echo $$?),127)
+ifeq ($(shell uname),Darwin)
+	brew install shellcheck
+else
+	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+	sudo apt-get update -qq && sudo apt-get install -qq -y shellcheck
+endif
+endif
+
+bats:
+ifeq ($(shell bats > /dev/null 2>&1 ; echo $$?),127)
+ifeq ($(shell uname),Darwin)
+	brew install shellcheck
+else
+	sudo add-apt-repository ppa:duggan/bats --yes
+	sudo apt-get update -qq && sudo apt-get install -qq -y bats
+endif
+endif
+
+ci-dependencies: shellcheck bats
+
+lint:
+	# these are disabled due to their expansive existence in the codebase. we should clean it up though
+	# SC2046: Quote this to prevent word splitting. - https://github.com/koalaman/shellcheck/wiki/SC2046
+	# SC2068: Double quote array expansions, otherwise they're like $* and break on spaces. - https://github.com/koalaman/shellcheck/wiki/SC2068
+	# SC2086: Double quote to prevent globbing and word splitting - https://github.com/koalaman/shellcheck/wiki/SC2086
+	@echo linting...
+	@$(QUIET) find ./ -maxdepth 1 -not -path '*/\.*' | xargs file | egrep "shell|bash" | awk '{ print $$1 }' | sed 's/://g' | xargs shellcheck -e SC2046,SC2068,SC2086
+
+setup:
+	$(MAKE) ci-dependencies
+
+test: setup lint

--- a/README.md
+++ b/README.md
@@ -1,40 +1,22 @@
-#dokku-multi-buildpack
+# #dokku-multi-buildpack [![Build Status](https://img.shields.io/travis/alexpauldub/dokku-multi-buildpack.svg?branch=master "Build Status")](https://travis-ci.org/pauldub/dokku-multi-buildpack)
 
-dokku-multi-buildpack is a plugin for [dokku](http://dokku.viewdocs.io/dokku) that injects
+dokku-multi-buildpack is a plugin for [dokku](https://github.com/progrium/dokku) that injects
 [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi) into buildstep, allowing the use of multiple buildpacks.
 
-## Installation
+## requirements
 
-```sh
-git clone https://github.com/pauldub/dokku-multi-buildpack.git /var/lib/dokku/plugins/dokku-multi-buildpack
+- dokku 0.3.0+ (0.4.x has this functionality built-in)
+- docker 1.6.x+
+
+## installation
+
+```shell
+# on 0.3.x
+cd /var/lib/dokku/plugins
+git clone https://github.com/pauldub/dokku-multi-buildpack.git dokku-multi-buildpack
+dokku plugins-install
 ```
-
-All future deployments will use supervisord to start all processes.
 
 ## License
 
 The MIT License (MIT)
-
-Copyright (c) 2013 Paul d'Hubert
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-[dokku](https://github.com/progrium/dokku)
-
-[super](http://supervisord.org)

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "injects heroku-buildpack-multi into your dokku deploys"
+version = "1.0.0"
+[plugin.config]

--- a/pre-build
+++ b/pre-build
@@ -1,5 +1,7 @@
-#!/bin/bash
-APP="$1"; IMAGE=dokku/"$1"
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+APP="$1"; IMAGE=dokku/"$APP"
 
 echo "-----> Injecting heroku-multi-buildpack ..."
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -1,0 +1,1 @@
+pre-build


### PR DESCRIPTION
Honestly, also not needed in 0.3.x, as you could manually set the buildpack url and create a .buildpacks file... But best we have correct documentation nonetheless!

Closes #7
